### PR TITLE
TickChanger - Change command function of `gte`

### DIFF
--- a/tickchanger/main.py
+++ b/tickchanger/main.py
@@ -60,5 +60,5 @@ class TickChanger(commands.Cog):
 
     @commands.command(name="gettickemoji", aliases=["gte"])
     @commands.is_owner()
-    async def ste(self, ctx: FakeContext):
+    async def gte(self, ctx: FakeContext):
         return await ctx.send(f"Your current tick emoji is {await self.config.tick_emoji()}")


### PR DESCRIPTION
I took a quick look at the code and noticed that `async def ste` was listed twice, once for the command it's supposed to be, and then for the `gettickemoji` command. So, I changed the second `ste` to a `gte` and fixed it.

It's such a minor change that I didn't really update the version number or anything.

As an aside:
![image](https://user-images.githubusercontent.com/4114117/147416575-127aa4ba-4847-465f-a5d7-e23ced3bd62f.png)
Maybe the description could use an update, but I don't know what to, but figured I'd point it out.