### PR TITLE
[giveaways] Fix display of `gset show` and formatting on `g explain`

### DIFF
--- a/giveaways/gset.py
+++ b/giveaways/gset.py
@@ -18,16 +18,14 @@ class Gset(Giveaways, name="Giveaways"):
     def __init__(self, bot: Red):
         super().__init__(bot)
 
-    @commands.group(
-        name="giveawaysettings", aliases=["gset", "giveawaysetting"], invoke_without_command=True
-    )
+    @commands.group(name="giveawaysettings", aliases=["gset", "giveawaysetting"])
     @commands.admin_or_permissions(administrator=True)
     async def gset(self, ctx):
         """
         Customize giveaways to how you want them.
 
         All subcommands represent a separate settings."""
-        await ctx.send_help("gset")
+        pass
 
     @gset.command(name="gmsg", usage="<message>")
     @commands.admin_or_permissions(administrator=True)
@@ -432,31 +430,22 @@ class Gset(Giveaways, name="Giveaways"):
         color = discord.Color(settings.color) if settings.color else await ctx.embed_color()
         show_defaults = settings.show_defaults
 
+        message = (
+            f"**Message:** {message}\n"
+            f"**Reaction Emoji:** {emoji}\n"
+            f"**Will the winner be dm'ed?:** {winnerdm}\n"
+            f"**Will the host be dm'ed?:** {hostdm}\n"
+            f"**Will users be dmed if their reaction is removed?:** {settings.unreactdm}\n"
+            f"**Auto delete Giveaway Commands?:** {autodelete}\n"
+            f"**Embed color: **{color}\n"
+            f"**Show defaults in giveaway embed?: **{show_defaults}\n"
+            f"**Giveaway Thank message:** {box(tmsg)}\n"
+            f"**Giveaway Ending message:** {box(endmsg)}\n"
+            f"**Giveaway Managers:** {humanize_list([ctx.guild.get_role(manager).mention for manager in managers if ctx.guild.get_role(manager)]) if managers else 'No Managers set. Requires manage message permission or bots mod role.'}"
+        )
         embed = discord.Embed(
             title=f"Giveaway Settings for **__{ctx.guild.name}__**",
-            description=f"""
-**Giveaway Managers:** {humanize_list([ctx.guild.get_role(manager).mention for manager in managers if ctx.guild.get_role(manager)]) if managers else "No managers set. Requires manage message permission or bot's mod role."}
-
-**Message:** {message}
-
-**Reaction Emoji:** {emoji}
-
-**Will the winner be dm'ed?:** {winnerdm}
-
-**Will the host be dm'ed?:** {hostdm}
-
-**Will users be dmed if their reaction is removed?:** {settings.unreactdm}
-
-**Auto delete Giveaway Commands?:** {autodelete}
-
-**Embed color: **{color}
-
-**Show defaults in giveaway embed?: **{show_defaults}
-
-**Giveaway Thank message:** {box(tmsg)}
-
-**Giveaway Ending message:** {box(endmsg)}\n
-			""",
+            description=message,
             color=color,
         )
 

--- a/giveaways/main.py
+++ b/giveaways/main.py
@@ -70,15 +70,15 @@ class Giveaways(commands.Cog):
             else:
                 if not await self.config.sent_message():
                     await self.bot.send_to_owners(
-                        f"Thanks for installing and using my Giveaways cog. "
-                        f"This cog has a requirements system for the giveaways and one of "
-                        f"these requirements type is amari levels. "
-                        f"If you don't know what amari is, ignore this message. "
-                        f"But if u do, you need an Amari auth key for these to work, "
-                        f"go to this website: https://forms.gle/TEZ3YbbMPMEWYuuMA "
-                        f"and apply to get the key. You should probably get a response within "
-                        f"24 hours but if you don't, visit this server for information: https://discord.gg/6FJhupDHS6 "
-                        f"You can then set the amari api key with the `[p]set api amari auth,<api key>` command"
+                        "Thanks for installing and using my Giveaways cog. "
+                        "This cog has a requirements system for the giveaways and one of "
+                        "these requirements type is amari levels. "
+                        "If you don't know what amari is, ignore this message. "
+                        "But if u do, you need an Amari auth key for these to work, "
+                        "go to this website: <https://forms.gle/TEZ3YbbMPMEWYuuMA> "
+                        "and apply to get the key. You should probably get a response within "
+                        "24 hours but if you don't, visit this server for information: https://discord.gg/6FJhupDHS6 "
+                        "You can then set the amari api key with the `[p]set api amari auth,<api key>` command"
                     )
                     await self.config.sent_message.set(True)
 
@@ -326,9 +326,7 @@ class Giveaways(commands.Cog):
 
     # < ----------------- The Actual Commands ----------------- > #
 
-    @commands.group(
-        name="giveaway", aliases=["g"], invoke_without_command=True, cooldown_after_parsing=True
-    )
+    @commands.group(name="giveaway", aliases=["g"], cooldown_after_parsing=True)
     @commands.guild_only()
     @is_manager()
     async def g(self, ctx: commands.Context):
@@ -337,7 +335,7 @@ class Giveaways(commands.Cog):
 
         Including `start`, `end` and `reroll`
         """
-        await ctx.send_help(ctx.command)
+        pass
 
     @g.command(
         name="start", aliases=["s"], usage="[time] <winners> [requirements] <prize> [flags]"
@@ -897,27 +895,27 @@ class Giveaways(commands.Cog):
     > is that the bot sends an embed containing information such as the prize,
     > the amount of winners, the requirements and the time it ends.
 
-    > People have to react to an emoji set by you through the `{ctx.prefix}gset emoji` command (defaults to :tada: )
+    > People have to react to an emoji set by you through the `{ctx.clean_prefix}gset emoji` command (defaults to :tada: )
     > and after the time to end has come for the giveaway to end, the bot will choose winners from the list of
     > people who reacted and send their mentions in the channel and edit the original embedded message.
 
-    > You can also set multipliers for roles which increase the chances of people with that role to win in a giveaway. `{ctx.prefix}gset multi`
+    > You can also set multipliers for roles which increase the chances of people with that role to win in a giveaway. `{ctx.clean_prefix}gset multi`
     > These multipliers stack and a user's entries in a giveaway add up for each role multiplier they have.
 
     > The format to add multis is:
-        `{ctx.prefix}gset multi add <role id or mention> <multi>`
+        `{ctx.clean_prefix}gset multi add <role id or mention> <multi>`
 
     > And to remove is the same:
-        `{ctx.prefix}gset multi remove <role id or mention>`
+        `{ctx.clean_prefix}gset multi remove <role id or mention>`
 
     > To see all active role multipliers:
-        `{ctx.prefix}gset multi`
+        `{ctx.clean_prefix}gset multi`
 
 ***__Requirements:__ ***
     > You can set requirements for the people who wish to join the giveaways.
     > These requirements can be either of role requirements or AmariBot level requirements.
     > Requirements are provided after the time and no. of winners like so:
-        *{ctx.prefix}g start <time> <no. of winners> <requirements> <prize> [flags]*
+        *{ctx.clean_prefix}g start <time> <no. of winners> <requirements> <prize> [flags]*
 
     > The format to specify a requirements is as follows:
 
@@ -953,7 +951,7 @@ class Giveaways(commands.Cog):
 
     > Here's another more complicated example:
 
-    >    **{ctx.prefix}g start 1h30m 1 somerolemention[bypass];;123456789[blacklist];;12[alvl]**
+    >    **{ctx.clean_prefix}g start 1h30m 1 somerolemention[bypass];;123456789[blacklist];;12[alvl]**
 
     ***NOTE***:
         Bypass overrides blacklist, so users with even one bypass role specified
@@ -979,13 +977,13 @@ class Giveaways(commands.Cog):
         This sends a separate embed after the main giveaway one stating a message give by you.
 
     > *--ping* [argless]
-        This flag pings the set role. ({ctx.prefix}gset pingrole)
+        This flag pings the set role. ({ctx.clean_prefix}gset pingrole)
 
     > *--thank* [argless]
-        This flag also sends a separate embed with a message thanking the donor. The message can be changed with `{ctx.prefix}gset tmsg`
+        This flag also sends a separate embed with a message thanking the donor. The message can be changed with `{ctx.clean_prefix}gset tmsg`
 
     > *--no-defaults* [argless]
-        This disables the default bypass and blacklist roles set by you with the `{ctx.prefix}gset blacklist` and `{ctx.prefix}gset bypass`
+        This disables the default bypass and blacklist roles set by you with the `{ctx.clean_prefix}gset blacklist` and `{ctx.clean_prefix}gset bypass`
 
     > *--ends-at*/*--end-in*
         This flag allows you to pass a date/time to end the giveaway at or just a duration. This will override the duration you give in the command invocation.
@@ -1025,32 +1023,32 @@ class Giveaways(commands.Cog):
     > There are a bunch of giveaway settings that you can change.
 
     > **Auto deletion of giveaway commands**
-        You can set whether giveaway command invocations get deleted themselves or not. `{ctx.prefix}gset autodelete true`
+        You can set whether giveaway command invocations get deleted themselves or not. `{ctx.clean_prefix}gset autodelete true`
 
     > **Giveaway headers**
-        The message above the giveaway can also be changed. `{ctx.prefix}gset gmsg`
+        The message above the giveaway can also be changed. `{ctx.clean_prefix}gset gmsg`
 
     > **Giveaway emoji**
-        The emoji to which people must react to enter a giveaway. This defaults to :tada: but can be changed to anything. `{ctx.prefix}gset emoji`
+        The emoji to which people must react to enter a giveaway. This defaults to :tada: but can be changed to anything. `{ctx.clean_prefix}gset emoji`
 
     > **Giveaway pingrole**
-        The role that gets pinged when you use the `--ping` flag. `{ctx.prefix}gset pingrole`
+        The role that gets pinged when you use the `--ping` flag. `{ctx.clean_prefix}gset pingrole`
 
     > **Thank message**
-        The message sent when you use the `--thank` flag. `{ctx.prefix}gset tmsg`
+        The message sent when you use the `--thank` flag. `{ctx.clean_prefix}gset tmsg`
 
     > **Ending message**
-        The message sent when the giveaway ends containing the winner mentions. `{ctx.prefix}gset endmsg`
+        The message sent when the giveaway ends containing the winner mentions. `{ctx.clean_prefix}gset endmsg`
 
     > **Default blacklist**
-        The roles that are by default blacklisted from giveaways. `{ctx.prefix}gset blacklist`
+        The roles that are by default blacklisted from giveaways. `{ctx.clean_prefix}gset blacklist`
 
     > **Default bypass**
-        The roles that are by default able to bypass requirements in giveaways. `{ctx.prefix}gset bypass`
+        The roles that are by default able to bypass requirements in giveaways. `{ctx.clean_prefix}gset bypass`
 
     > **Show defaults in giveaway embed**
         It gets kinda janky when you have multiple defaults set and the giveaway embed becomes too long.
-        Easy way out, is to simply disable showing the defaults in the embed ;) `{ctx.prefix}gset showdefaults`
+        Easy way out, is to simply disable showing the defaults in the embed ;) `{ctx.clean_prefix}gset showdefaults`
 
     > **Embed Color**
         The default embed color doesn't look good to you? now worries, you can now customize the color for your server.

--- a/giveaways/main.py
+++ b/giveaways/main.py
@@ -46,7 +46,7 @@ class Giveaways(commands.Cog):
     This cog is a very complex cog and could be resource intensive on your bot.
     Use `giveaway explain` command for an indepth explanation on how to use the commands."""
 
-    __version__ = "2.0.0"
+    __version__ = "2.0.1"
     __author__ = ["crayyy_zee#2900"]
 
     def __init__(self, bot: Red):


### PR DESCRIPTION
## Removed
- Removed unused F strings.
- Removed `invoke_without_command` because you dont really need this here. because it does open the help of settings and the giveawy commands without this.

## Fixed
- `gset show` is now more mobile friendly to actually look at. (not really but its not showing space this time).
- `g expain` now use `ctx.clean_prefix` instead of `ctx.prefix`.

**Before** 
![5nDTjH3MD](https://user-images.githubusercontent.com/63972751/153379404-020159a0-cb84-490f-a8a5-2883b7a20bdf.png)
**After**
![5nDTrGhLg](https://user-images.githubusercontent.com/63972751/153379422-a292b326-8b62-41d0-8fcc-1bb89c9ce3d5.png)

It makes the mentionable prefix shows the actual prefix instead of showing the bot's ID, this makes it much easier for the people who actually use mentionable. 