### PR TITLE
[DonationLogging] fix install_msg and send help in donoset

### DIFF
--- a/donationlogging/dono.py
+++ b/donationlogging/dono.py
@@ -797,6 +797,7 @@ class DonationLogging(commands.Cog):
     async def donoset(self, ctx):
         """
         Base command for changing donation settings for your server."""
+        return await ctx.send_help()
 
     @donoset.group(name="autorole", invoke_without_command=True)
     @commands.mod_or_permissions(administrator=True)

--- a/donationlogging/info.json
+++ b/donationlogging/info.json
@@ -4,7 +4,7 @@
     "short": "Record user donations in server",
     "description": "Helps server staff to log people donations in an easier way. Allows you to setup a channel to log actions in this cog, setup roles to be auto assigned on a certain donation amount, add donations, reduce donations, reset donations and check yours other's donations.",
     "end_user_data_statement": "This cog stores End User Data when storing the donations of a user. If a user requests data-deletion, all their donations will be removed from the bot.",
-    "install_msg": "Thanks for installing DonationLogging. Load the cog with `[p]load donocog` and see all its commands with `[p]help dono` and `[p]help donoset`.",
+    "install_msg": "Thanks for installing DonationLogging. Load the cog with `[p]load donationlogging` and see all its commands with `[p]help dono` and `[p]help donoset`.",
     "author": [
         "crayyy_zee"
     ],


### PR DESCRIPTION
info.json:
This commit changed the `[p]load donocog` on "install_msg" to `[p]load donationlogging` (Since that's the cog name)

dono.py:
This commit fixes where if only `[p]donoset` invoked (without subcommands), it would show the available subcommands (so you don't have to use `[p]help donoset`)