### PR TITLE
Add listnotes command to `Notes` cog

### DIFF
--- a/keywordpoints/main.py
+++ b/keywordpoints/main.py
@@ -110,7 +110,9 @@ class KeyWordPoints(commands.Cog):
         await self.config.custom(KEYWORDPOINTS).set(self.settings_cache)
         for guild_id, member_data in self.member_cache.items():
             for member_id, member_details in member_data.items():
-                await self.config.member_from_ids(guild_id, member_id).points.set(member_details["points"])
+                await self.config.member_from_ids(guild_id, member_id).points.set(
+                    member_details["points"]
+                )
 
     @_update_config.before_loop
     async def before_loop(self):

--- a/notes/info.json
+++ b/notes/info.json
@@ -7,6 +7,7 @@
     "author": [
         "crayyy_zee"
     ],
+    "requirements": ["tabualte"],
     "required_cogs": {},
     "tags": [
         "notes",

--- a/notes/notes.py
+++ b/notes/notes.py
@@ -10,6 +10,7 @@ from redbot.core import Config, commands
 from redbot.core.bot import Red
 from redbot.core.utils.chat_formatting import humanize_list
 from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
+from tabulate import tabulate
 
 from .models import NoteType, UserNote
 
@@ -235,6 +236,22 @@ class Notes(commands.Cog):
         # await paginator.start()
 
         await menu(ctx, embeds, DEFAULT_CONTROLS)
+        
+    @commands.command(name="listnotes")
+    @commands.mod_or_permissions(manage_messages=True)
+    async def listnotes(self, ctx: commands.Context):
+        notes = self._get_notes(ctx.guild)
+        
+        data = sorted([(i, u, len(notes)) for i, (user, notes) in enumerate(notes.items()) if (u := ctx.guild.get_member(user))], key=lambda x: x[2], reverse=True)
+        
+        tabbed = tabulate(data, headers=["User", "Notes"], tablefmt="rst")
+        
+        return await ctx.send(
+            embed=discord.Embed(
+                title="Notes for this server",
+                description=f"```rst\n{tabbed}```",
+            )
+        )
 
     @commands.command()
     @commands.mod_or_permissions(manage_messages=True)

--- a/notes/notes.py
+++ b/notes/notes.py
@@ -236,16 +236,24 @@ class Notes(commands.Cog):
         # await paginator.start()
 
         await menu(ctx, embeds, DEFAULT_CONTROLS)
-        
+
     @commands.command(name="listnotes")
     @commands.mod_or_permissions(manage_messages=True)
     async def listnotes(self, ctx: commands.Context):
         notes = self._get_notes(ctx.guild)
-        
-        data = sorted([(i, u, len(notes)) for i, (user, notes) in enumerate(notes.items()) if (u := ctx.guild.get_member(user))], key=lambda x: x[2], reverse=True)
-        
+
+        data = sorted(
+            [
+                (i, u, len(notes))
+                for i, (user, notes) in enumerate(notes.items())
+                if (u := ctx.guild.get_member(user))
+            ],
+            key=lambda x: x[2],
+            reverse=True,
+        )
+
         tabbed = tabulate(data, headers=["User", "Notes"], tablefmt="rst")
-        
+
         return await ctx.send(
             embed=discord.Embed(
                 title="Notes for this server",


### PR DESCRIPTION
This PR adds a command that basically just sends an embed listing how many users have how many notes.
Resolves #35