### PR TITLE
[Notes] Fix typo in requirement.

### DIFF
--- a/notes/info.json
+++ b/notes/info.json
@@ -7,7 +7,7 @@
     "author": [
         "crayyy_zee"
     ],
-    "requirements": ["tabualte"],
+    "requirements": ["tabulate"],
     "required_cogs": {},
     "tags": [
         "notes",


### PR DESCRIPTION
Fixed spelling mistake of `tabulate` while it said `tabualte`.